### PR TITLE
Add support for 10.0.14393.693

### DIFF
--- a/winspector.py
+++ b/winspector.py
@@ -6,13 +6,15 @@ import sys
 from requests.exceptions import HTTPError, ConnectTimeout
 
 knownWindowsLayers = {
-    "sha256:3889bb8d808bbae6fa5a33e07093e65c31371bcf9e4c38c21be6b9af52ad1548": "microsoft/windowsservercore:10.0.14393.576 update",
-    "sha256:04ee5d718c7adc0144556d740900f778129e41be806c95191710d1d92051a7b3": "microsoft/windowsservercore:10.0.14393.576 base",
+    "sha256:3430754e4d171ead00cf6766797a28abf3caf236f6c92c5c346ea2ad3955a129": "microsoft/windowsservercore:10.0.14393.693 update",
+    "sha256:3889bb8d808bbae6fa5a33e07093e65c31371bcf9e4c38c21be6b9af52ad1548": "microsoft/windowsservercore:10.0.14393.576 base",
+    "sha256:04ee5d718c7adc0144556d740900f778129e41be806c95191710d1d92051a7b3": "microsoft/windowsservercore:10.0.14393.576 update",
     "sha256:d33fff6043a134da85e10360f9932543f1dfc0c3a22e1edd062aa9b088a86c5b": "microsoft/windowsservercore:10.0.14393.447 update",
     "sha256:de5064718b3f2749727c8b5ffddf2da7698189277afe0df6fc0a57ad573bca0f": "microsoft/windowsservercore:10.0.14393.321 update",
     "sha256:9c7f9c7d9bc2915388ecc5d08e89a7583658285469d7325281f95d8ee279cc60": "microsoft/windowsservercore:10.0.14393.206 base",
     "sha256:1239394e5a8ab79fbd3b751dc5d98decf5886f14339958fdf5c1f96c89da58a7": "microsoft/windowsservercore:10.0.14300.1030",
 
+    "sha256:3ac17e2e6106d09a44642a437c318092eddd284afea0b4e707e89f6cec7a18ef": "microsoft/nanoserver:10.0.14393.693 update",
     "sha256:10bf725c5388a1909f7184467b5ec75dbad3ece68508aa5fa4074baa0b20cc6f": "microsoft/nanoserver:10.0.14393.576 update",
     "sha256:bce2fbc256ea437a87dadac2f69aabd25bed4f56255549090056c1131fad0277": "microsoft/nanoserver:10.0.14393.576 base",
     "sha256:482ab31872a23b32cbdeca13edb7a0b97290714c0b5edcce96fbb3e34221ea91": "microsoft/nanoserver:10.0.14393.447 update",


### PR DESCRIPTION
There are new Windows base images for microsoft/windowsservercore and microsoft/nanoserver with tag 10.0.14939.693. So add the new digests for the two update layers.

Signed-off-by: Stefan Scherer <scherer_stefan@icloud.com>