### PR TITLE
Use alpine for Linux again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.0
+FROM python:3.6.0-alpine
 ENV PYTHON_UNBUFFERED 1
 RUN pip install --upgrade pip
 ADD requirements.txt /


### PR DESCRIPTION
Use `python:3.6.0-alpine` again to reduce image size for Linux.
