### PR TITLE
Build Windows Docker image in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,12 @@
 version: 1.0.{build}
+image: Windows Server 2016
+
 environment:
   DOCKER_USER:
     secure: LjNiW/ZWrfVIJn3Mc9foeg==
   DOCKER_PASS:
     secure: 4gsl5WiqIztEWhL5fuhp9X0qT/mKg9fYzKYUUPf5WStIuNddv0fvIKGmvvyuFzzd
 install:
-  - choco install -y docker -pre
   - docker version
 
 build_script:

--- a/build.ps1
+++ b/build.ps1
@@ -6,13 +6,6 @@ Write-Host Updating base images
 docker pull microsoft/windowsservercore
 docker pull microsoft/nanoserver
 
-Write-Host Removing old images
-$ErrorActionPreference = 'SilentlyContinue';
-docker rmi $(docker images --no-trunc --format '{{.Repository}}:{{.Tag}}' | sls -notmatch -pattern '(REPOSITORY|microsoft\/(windowsservercore|nanoserver))')
-$ErrorActionPreference = 'Stop';
-Write-Host Prune system
-docker system prune -f
-
 docker build -t winspector -f Dockerfile.windows .
 
 docker images


### PR DESCRIPTION
Update to latest AppVeyor image with Docker installed.
Simplified build steps as the cleanup of old images is no longer needed.
