### PR TITLE
Add insider

### DIFF
--- a/Dockerfile.insider
+++ b/Dockerfile.insider
@@ -1,0 +1,7 @@
+FROM stefanscherer/python-windows:3.6.3-insider
+ENV PYTHON_UNBUFFERED 1
+RUN pip install --upgrade pip
+ADD requirements.txt /
+RUN pip install -r /requirements.txt
+ADD winspector.py /
+ENTRYPOINT ["python", "/winspector.py"]

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,19 @@
+image: stefanscherer/winspector:test2
+manifests:
+  -
+    image: stefanscherer/winspector:linux-1.13.0
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: stefanscherer/winspector:windows-1.13.0
+    platform:
+      architecture: amd64
+      version: 10.0.14393.1593
+      os: windows
+  -
+    image: stefanscherer/winspector:insider
+    platform:
+      architecture: amd64
+      version: 10.0.16278.1000
+      os: windows


### PR DESCRIPTION
* Add a `Dockerfile.insider` to build an image based on the microsoft/nanoserver-insider image.
* Add a `manifest.yaml` to push a manifest list with two Windows images with different OS version.

```
manifest-tool push from-spec manifest.yml
```
